### PR TITLE
Rework rust module server config

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -34,7 +34,7 @@
 
       webServer = lib.mkOption {
         type = lib.types.nullOr (lib.types.submodule webServerSubmodule);
-        description = "If set, generates a Nixos configuration with an http server and sets up garnix to deploy this";
+        description = "If set, generates a Nixos configuration with an http server";
         default = null;
       };
 


### PR DESCRIPTION
* Rework `serverCommand` str option into optional `webServer` submodule option.
* Add nginx reverse proxy when `webServer` is enabled
* Output garnix config to auto-deploy configured server (using option from https://github.com/garnix-io/garnix-lib/pull/9)