### PR TITLE
Remove `nixpkgs` input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -15,26 +15,9 @@
         "type": "github"
       }
     },
-    "nixpkgs": {
-      "locked": {
-        "lastModified": 1733550349,
-        "narHash": "sha256-NcGumB4Lr6KSDq+nIqXtNA8QwAQKDSZT7N9OTGWbTrs=",
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "rev": "e2605d0744c2417b09f8bf850dfca42fcf537d34",
-        "type": "github"
-      },
-      "original": {
-        "owner": "NixOS",
-        "ref": "nixos-24.11",
-        "repo": "nixpkgs",
-        "type": "github"
-      }
-    },
     "root": {
       "inputs": {
-        "crane": "crane",
-        "nixpkgs": "nixpkgs"
+        "crane": "crane"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -7,75 +7,93 @@
     [Documentation](https://garnix.io/docs/modules/rust) - [Source](https://github.com/garnix-io/rust-module).
   '';
   inputs.crane.url = "github:ipetkov/crane";
-  outputs = { self, crane }: {
-    garnixModules.default = { pkgs, lib, config, ... }:
-    let
-      webServerSubmodule.options = {
-        command = lib.mkOption
-          {
-            type = lib.types.nonEmptyStr;
-            description = "The command to run to start the server in production.";
-            example = "server --port \"$PORT\"";
-          } // { name = "server command"; };
+  outputs =
+    { self, crane }:
+    {
+      garnixModules.default =
+        {
+          pkgs,
+          lib,
+          config,
+          ...
+        }:
+        let
+          webServerSubmodule.options = {
+            command =
+              lib.mkOption {
+                type = lib.types.nonEmptyStr;
+                description = "The command to run to start the server in production.";
+                example = "server --port \"$PORT\"";
+              }
+              // {
+                name = "server command";
+              };
 
-        port = lib.mkOption {
-          type = lib.types.port;
-          description = "Port to forward incoming HTTP requests to. The server command has to listen on this port. This also sets the PORT environment variable for the server command.";
-          example = 8000;
-          default = 8000;
-        };
+            port = lib.mkOption {
+              type = lib.types.port;
+              description = "Port to forward incoming HTTP requests to. The server command has to listen on this port. This also sets the PORT environment variable for the server command.";
+              example = 8000;
+              default = 8000;
+            };
 
-        path = lib.mkOption
-          {
-            type = lib.types.nonEmptyStr;
-            description = "Path your Rust server will be hosted on.";
-            default = "/";
-          } // { name = "API path"; };
-      };
+            path =
+              lib.mkOption {
+                type = lib.types.nonEmptyStr;
+                description = "Path your Rust server will be hosted on.";
+                default = "/";
+              }
+              // {
+                name = "API path";
+              };
+          };
 
-      rustSubmodule.options = {
-        src = lib.mkOption
-          {
-            type = lib.types.path;
-            description = "A path to the directory containing `Cargo.lock`, `Cargo.toml`, and `src`.";
-            example = "./.";
-          } // { name = "source directory"; };
+          rustSubmodule.options = {
+            src =
+              lib.mkOption {
+                type = lib.types.path;
+                description = "A path to the directory containing `Cargo.lock`, `Cargo.toml`, and `src`.";
+                example = "./.";
+              }
+              // {
+                name = "source directory";
+              };
 
-        webServer = lib.mkOption {
-          type = lib.types.nullOr (lib.types.submodule webServerSubmodule);
-          description = "Whether to build a server configuration based on this project and deploy it to the garnix cloud.";
-          default = null;
-        };
+            webServer = lib.mkOption {
+              type = lib.types.nullOr (lib.types.submodule webServerSubmodule);
+              description = "Whether to build a server configuration based on this project and deploy it to the garnix cloud.";
+              default = null;
+            };
 
-        devTools = lib.mkOption
-          {
-            type = lib.types.listOf lib.types.package;
-            description = "A list of packages make available in the devshell for this project (and `default` devshell). This is useful for things like LSPs, formatters, etc.";
-            default = [ ];
-          } // { name = "development tools"; };
+            devTools =
+              lib.mkOption {
+                type = lib.types.listOf lib.types.package;
+                description = "A list of packages make available in the devshell for this project (and `default` devshell). This is useful for things like LSPs, formatters, etc.";
+                default = [ ];
+              }
+              // {
+                name = "development tools";
+              };
 
-        buildDependencies = lib.mkOption {
-          type = lib.types.listOf lib.types.package;
-          description = "A list of dependencies required to build this package. They are made available in the devshell, and at build time.";
-          default = [ ];
-        };
+            buildDependencies = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              description = "A list of dependencies required to build this package. They are made available in the devshell, and at build time.";
+              default = [ ];
+            };
 
-        runtimeDependencies = lib.mkOption {
-          type = lib.types.listOf lib.types.package;
-          description = "A list of dependencies required at runtime. They are made available in the devshell, at build time, and are available on the server at runtime.";
-          default = [ ];
-        };
-      };
+            runtimeDependencies = lib.mkOption {
+              type = lib.types.listOf lib.types.package;
+              description = "A list of dependencies required at runtime. They are made available in the devshell, at build time, and are available on the server at runtime.";
+              default = [ ];
+            };
+          };
 
           craneLib = crane.mkLib pkgs;
-          craneArgsByProject = builtins.mapAttrs
-            (name: projectConfig: rec {
-              src = craneLib.cleanCargoSource projectConfig.src;
-              cargoArtifacts = craneLib.buildDepsOnly { inherit src buildInputs; };
-              buildInputs = projectConfig.buildDependencies ++ projectConfig.runtimeDependencies;
-            })
-            config.rust;
-    in
+          craneArgsByProject = builtins.mapAttrs (name: projectConfig: rec {
+            src = craneLib.cleanCargoSource projectConfig.src;
+            cargoArtifacts = craneLib.buildDepsOnly { inherit src buildInputs; };
+            buildInputs = projectConfig.buildDependencies ++ projectConfig.runtimeDependencies;
+          }) config.rust;
+        in
         {
           options = {
             rust = lib.mkOption {
@@ -85,84 +103,91 @@
           };
 
           config = {
-            packages = builtins.mapAttrs
-              (name: projectConfig:
-                craneLib.buildPackage {
-                  inherit (craneArgsByProject.${name}) src cargoArtifacts buildInputs;
-                }
-              )
-              config.rust;
+            packages = builtins.mapAttrs (
+              name: projectConfig:
+              craneLib.buildPackage {
+                inherit (craneArgsByProject.${name}) src cargoArtifacts buildInputs;
+              }
+            ) config.rust;
 
-            checks = lib.foldlAttrs
-              (acc: name: projectConfig: acc // {
+            checks = lib.foldlAttrs (
+              acc: name: projectConfig:
+              acc
+              // {
                 "${name}-cargo-clippy" = craneLib.cargoClippy {
                   inherit (craneArgsByProject.${name}) src cargoArtifacts buildInputs;
                   cargoClippyExtraArgs = "--all-targets -- --deny warnings";
                 };
                 "${name}-cargo-fmt" = craneLib.cargoFmt { inherit (craneArgsByProject.${name}) src; };
-                "${name}-cargo-doc" = craneLib.cargoDoc { inherit (craneArgsByProject.${name}) src cargoArtifacts buildInputs; };
-              })
-              { }
-              config.rust;
+                "${name}-cargo-doc" = craneLib.cargoDoc {
+                  inherit (craneArgsByProject.${name}) src cargoArtifacts buildInputs;
+                };
+              }
+            ) { } config.rust;
 
-            devShells = builtins.mapAttrs
-              (name: projectConfig:
-                craneLib.devShell {
-                  packages =
-                    projectConfig.devTools ++
-                    projectConfig.buildDependencies ++
-                    projectConfig.runtimeDependencies;
-                }
-              )
-              config.rust;
+            devShells = builtins.mapAttrs (
+              name: projectConfig:
+              craneLib.devShell {
+                packages =
+                  projectConfig.devTools ++ projectConfig.buildDependencies ++ projectConfig.runtimeDependencies;
+              }
+            ) config.rust;
 
             nixosConfigurations =
               let
-                hasAnyWebServer =
-                  builtins.any (projectConfig: projectConfig.webServer != null)
-                    (builtins.attrValues config.rust);
+                hasAnyWebServer = builtins.any (projectConfig: projectConfig.webServer != null) (
+                  builtins.attrValues config.rust
+                );
               in
               lib.mkIf hasAnyWebServer {
                 default =
                   # Global NixOS configuration
-                  [{
-                    services.nginx = {
-                      enable = true;
-                      recommendedProxySettings = true;
-                      recommendedOptimisation = true;
-                      virtualHosts.default = {
-                        default = true;
-                      };
-                    };
-
-                    networking.firewall.allowedTCPPorts = [ 80 ];
-                  }]
-                  ++
-                  # Per project NixOS configuration
-                  (builtins.attrValues (builtins.mapAttrs
-                    (name: projectConfig: lib.mkIf (projectConfig.webServer != null) {
-                      environment.systemPackages = projectConfig.runtimeDependencies;
-
-                      systemd.services.${name} = {
-                        description = "${name} Rust garnix module";
-                        wantedBy = [ "multi-user.target" ];
-                        after = [ "network-online.target" ];
-                        wants = [ "network-online.target" ];
-                        environment.PORT = toString projectConfig.webServer.port;
-                        serviceConfig = {
-                          Type = "simple";
-                          DynamicUser = true;
-                          ExecStart = lib.getExe (pkgs.writeShellApplication {
-                            name = "start-${name}";
-                            runtimeInputs = [ config.packages.${name} ] ++ projectConfig.runtimeDependencies;
-                            text = projectConfig.webServer.command;
-                          });
+                  [
+                    {
+                      services.nginx = {
+                        enable = true;
+                        recommendedProxySettings = true;
+                        recommendedOptimisation = true;
+                        virtualHosts.default = {
+                          default = true;
                         };
                       };
 
-                      services.nginx.virtualHosts.default.locations.${projectConfig.webServer.path}.proxyPass = "http://localhost:${toString projectConfig.webServer.port}";
-                    })
-                    config.rust));
+                      networking.firewall.allowedTCPPorts = [ 80 ];
+                    }
+                  ]
+                  ++
+                  # Per project NixOS configuration
+                  (builtins.attrValues (
+                    builtins.mapAttrs (
+                      name: projectConfig:
+                      lib.mkIf (projectConfig.webServer != null) {
+                        environment.systemPackages = projectConfig.runtimeDependencies;
+
+                        systemd.services.${name} = {
+                          description = "${name} Rust garnix module";
+                          wantedBy = [ "multi-user.target" ];
+                          after = [ "network-online.target" ];
+                          wants = [ "network-online.target" ];
+                          environment.PORT = toString projectConfig.webServer.port;
+                          serviceConfig = {
+                            Type = "simple";
+                            DynamicUser = true;
+                            ExecStart = lib.getExe (
+                              pkgs.writeShellApplication {
+                                name = "start-${name}";
+                                runtimeInputs = [ config.packages.${name} ] ++ projectConfig.runtimeDependencies;
+                                text = projectConfig.webServer.command;
+                              }
+                            );
+                          };
+                        };
+
+                        services.nginx.virtualHosts.default.locations.${projectConfig.webServer.path}.proxyPass =
+                          "http://localhost:${toString projectConfig.webServer.port}";
+                      }
+                    ) config.rust
+                  ));
               };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -6,12 +6,10 @@
 
     [Documentation](https://garnix.io/docs/modules/rust) - [Source](https://github.com/garnix-io/rust-module).
   '';
-  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-24.11";
   inputs.crane.url = "github:ipetkov/crane";
-  outputs = { self, nixpkgs, crane }:
+  outputs = { self, crane }: {
+    garnixModules.default = { pkgs, lib, config, ... }:
     let
-      lib = nixpkgs.lib;
-
       webServerSubmodule.options = {
         command = lib.mkOption
           {
@@ -68,10 +66,7 @@
           default = [ ];
         };
       };
-    in
-    {
-      garnixModules.default = { pkgs, config, ... }:
-        let
+
           craneLib = crane.mkLib pkgs;
           craneArgsByProject = builtins.mapAttrs
             (name: projectConfig: rec {
@@ -80,7 +75,7 @@
               buildInputs = projectConfig.buildDependencies ++ projectConfig.runtimeDependencies;
             })
             config.rust;
-        in
+    in
         {
           options = {
             rust = lib.mkOption {


### PR DESCRIPTION
The `nixpkgs` dependency was only being used for library functions, and
these functions are only needed within `garnixModules.default` which
receives `lib` from `garnix-lib`. By removing the `nixpkgs` input we can
be assured that there is only one `nixpkgs` being used: the one passed
in from `garnix-lib`.